### PR TITLE
投稿削除機能の実装

### DIFF
--- a/app/controllers/v0/posts_controller.rb
+++ b/app/controllers/v0/posts_controller.rb
@@ -47,7 +47,19 @@ module V0
       elsif post.update(post_params)
         response_no_content
       end
+    end
 
+    def destroy
+      user = User.find_by_id(params[:user_id])
+      post = user&.post&.find_by_id(params[:id])
+
+      if !number?(params[:user_id]) || user.nil?
+        response_bad_request
+      elsif post.nil?
+        response_not_found
+      elsif post.destroy
+        response_no_content
+      end
     end
 
     private


### PR DESCRIPTION
- ユーザーIDと投稿IDを指定して特定の投稿を削除する機能を実装しました
- 以下の場合は400を返します
  - ユーザーIDが数字ではない
  - 指定されたユーザーIDのユーザーが存在しない
- 指定した投稿IDの投稿が存在しない場合は404を返します